### PR TITLE
Add transaction model

### DIFF
--- a/model/transaction.go
+++ b/model/transaction.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"math"
+	"time"
+)
+
+const expectedDateFormat = "2006-01-02"
+
+type Transaction struct {
+	ID              int     `json:"id"`
+	Description     string  `json:"description"`
+	Amount          float64 `json:"amount"`
+	TransactionDate string  `json:"transaction_date"`
+}
+
+// Validate checks the Transaction fields for validity.
+func (t *Transaction) Validate() string {
+	if len(t.Description) > 50 {
+		return "Description must be 50 characters or fewer"
+	}
+
+	if t.Amount <= 0 {
+		return "Amount must be greater than 0"
+	}
+
+	t.Amount = roundToCents(t.Amount)
+
+	if _, err := time.Parse(expectedDateFormat, t.TransactionDate); err != nil {
+		return "Transaction date must be in YYYY-MM-DD format"
+	}
+
+	return ""
+}
+
+// roundToCents rounds a float64 value to the nearest cent.
+func roundToCents(value float64) float64 {
+	return math.Round(value*100) / 100
+}

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestTransactionValidate(t *testing.T) {
+	tests := []struct {
+		name           string
+		transaction    Transaction
+		expectedResult string
+	}{
+		{
+			name: "Description longer than 50 characters",
+			transaction: Transaction{
+				Description:     "This is exactly 51 chars long. Oooooops, too long!!",
+				Amount:          1.00,
+				TransactionDate: "2020-01-01",
+			},
+			expectedResult: "Description must be 50 characters or fewer",
+		},
+		{
+			name: "Amount less than 0",
+			transaction: Transaction{
+				Description:     "Test",
+				Amount:          -0.01,
+				TransactionDate: "2020-01-01",
+			},
+			expectedResult: "Amount must be greater than 0",
+		},
+		{
+			name: "Amount equals to 0",
+			transaction: Transaction{
+				Description:     "Test",
+				Amount:          0.00,
+				TransactionDate: "2020-01-01",
+			},
+			expectedResult: "Amount must be greater than 0",
+		},
+		{
+			name: "Invalid date format",
+			transaction: Transaction{
+				Description:     "Test",
+				Amount:          1.00,
+				TransactionDate: "01-01-2020",
+			},
+			expectedResult: "Transaction date must be in YYYY-MM-DD format",
+		},
+		{
+			name: "Transaction with rounding up amount",
+			transaction: Transaction{
+				Description:     "Round up",
+				Amount:          1.006,
+				TransactionDate: "2020-01-01",
+			},
+			expectedResult: "",
+		},
+		{
+			name: "Valid transaction",
+			transaction: Transaction{
+				Description:     "This is exactly 50 characters long. Juuuust right.",
+				Amount:          0.01,
+				TransactionDate: "2020-01-01",
+			},
+			expectedResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.transaction.Validate()
+			if result != tt.expectedResult {
+				t.Errorf("Validate() = %v, want %v", result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+func TestRoundToCents(t *testing.T) {
+	tests := []struct {
+		name           string
+		amount         float64
+		expectedResult float64
+	}{
+		{
+			name:           "Round up",
+			amount:         1.006,
+			expectedResult: 1.01,
+		},
+		{
+			name:           "Round down",
+			amount:         1.005,
+			expectedResult: 1.00,
+		},
+		{
+			name:           "No rounding needed",
+			amount:         1.00,
+			expectedResult: 1.00,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roundToCents(tt.amount)
+			if got != tt.expectedResult {
+				t.Errorf("roundToCents() = %v, want %v", got, tt.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2 

# Changes

- Add the `transaction` model which includes the fields (`description`, `transaction date`, `amount` and `ID`)
- Add a `Validate()` func to the model which checks that:
  - Description: must not exceed 50 characters
  - Transaction date: must be a valid date format
  - Purchase amount: must be a valid positive amount rounded to the nearest cent
- Add unit tests