### PR TITLE
Add treasury integration

### DIFF
--- a/service/treasury.go
+++ b/service/treasury.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mvfavila/transactions/model"
+)
+
+// treasuryAPIBaseURL is the base URL for the Treasury Reporting Rates of Exchange API
+const expectedDateFormat = "2006-01-02"
+const treasuryAPIBaseURL = "https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v1/accounting/od/rates_of_exchange"
+
+// TreasuryRate represents a single exchange rate entry
+type TreasuryRate struct {
+	CurrencyCode  string  `json:"currency_code"`
+	CurrencyName  string  `json:"currency_name"`
+	ExchangeRate  float64 `json:"exchange_rate,string"`
+	RateDate      string  `json:"rate_date"`
+	SourceUpdated string  `json:"source_updated"`
+}
+
+// TreasuryResponse represents the API response structure
+type TreasuryResponse struct {
+	Data  []TreasuryRate `json:"data"`
+	Meta  interface{}    `json:"meta"`
+	Links interface{}    `json:"links"`
+}
+
+// FetchExchangeRates fetches exchange rates from the Treasury API
+func FetchExchangeRates(client *http.Client, country string, transaction *model.Transaction) ([]TreasuryRate, error) {
+	if country == "" {
+		return nil, fmt.Errorf("country is required")
+	}
+
+	var filter, err = getRequestFilter(country, transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make an HTTP GET request
+	resp, err := client.Get(fmt.Sprintf("%s?filter=%s", treasuryAPIBaseURL, filter))
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request to Treasury API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check if the response status code is successful
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Parse JSON response
+	var treasuryResponse TreasuryResponse
+	if err := json.Unmarshal(body, &treasuryResponse); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON response: %w", err)
+	}
+
+	return treasuryResponse.Data, nil
+}
+
+// getDateMinusSixMonths calculates the date that is six months prior to the given currentDate.
+func getDateMinusSixMonths(currentDate string) (string, error) {
+	if d, err := time.Parse(expectedDateFormat, currentDate); err == nil {
+		return d.AddDate(0, -6, 0).Format(expectedDateFormat), nil
+	}
+
+	return "", fmt.Errorf("transaction date must be in YYYY-MM-DD format")
+}
+
+// getRequestFilter generates a filter string for the Treasury API based on the given country and transaction.
+//
+// The filter string is based on the following criteria:
+// - country: the country of the transaction
+// - effective_date: the date of the transaction or the date 6 months prior to the transaction date, whichever is later.
+//
+// If the transaction date is invalid, an error is returned.
+func getRequestFilter(country string, transaction *model.Transaction) (string, error) {
+	var bottomDate string
+	var err error
+	if bottomDate, err = getDateMinusSixMonths(transaction.TransactionDate); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("country:eq:%s,effective_date:gte:%s,effective_date:lte:%s", country, bottomDate, transaction.TransactionDate), nil
+}

--- a/service/treasury_test.go
+++ b/service/treasury_test.go
@@ -28,7 +28,21 @@ func TestFetchExchangeRates(t *testing.T) {
 	// Mock response body
 	mockResponseBody := `{
 		"data": [
-			{"currency_code": "USD", "currency_name": "US Dollar", "exchange_rate": "1.0", "rate_date": "2025-01-13", "source_updated": "2025-01-13T12:00:00Z"}
+			{
+				"record_date": "2024-12-31",
+				"country": "Afghanistan",
+				"currency": "Afghani",
+				"country_currency_desc": "Afghanistan-Afghani",
+				"exchange_rate": "70.35",
+				"effective_date": "2024-12-31",
+				"src_line_nbr": "1",
+				"record_fiscal_year": "2025",
+				"record_fiscal_quarter": "1",
+				"record_calendar_year": "2024",
+				"record_calendar_quarter": "4",
+				"record_calendar_month": "12",
+				"record_calendar_day": "31"
+			}
 		],
 		"meta": {},
 		"links": {}
@@ -55,9 +69,9 @@ func TestFetchExchangeRates(t *testing.T) {
 		t.Fatalf("expected 1 rate, got %d", len(rates))
 	}
 
-	expectedRate := "US Dollar"
-	if rates[0].CurrencyName != expectedRate {
-		t.Errorf("expected currency name %s, got %s", expectedRate, rates[0].CurrencyName)
+	expectedRate := 70.35
+	if rates[0].ExchangeRate != expectedRate {
+		t.Errorf("expected currency name %.2f, got %.2f", expectedRate, rates[0].ExchangeRate)
 	}
 }
 
@@ -117,21 +131,21 @@ func TestGetDateMinusSixMonths(t *testing.T) {
 	}
 }
 
-func TestGetRequestFilter(t *testing.T) {
+func TestGetRequestQuery(t *testing.T) {
 	var getRequestFilterTests = []struct {
 		country         string
 		transactionDate string
 		expectedFilter  string
 		expectedError   error
 	}{
-		{"Autralia", "2020-01-01", "country:eq:Autralia,effective_date:gte:2019-07-01,effective_date:lte:2020-01-01", nil},
-		{"Austria", "2020-02-29", "country:eq:Austria,effective_date:gte:2019-08-29,effective_date:lte:2020-02-29", nil},
+		{"Autralia", "2020-01-01", "country:eq:Autralia,effective_date:gte:2019-07-01,effective_date:lte:2020-01-01&sort=-effective_date", nil},
+		{"Austria", "2020-02-29", "country:eq:Austria,effective_date:gte:2019-08-29,effective_date:lte:2020-02-29&sort=-effective_date", nil},
 		{"Brazil", "abc", "", fmt.Errorf("transaction date must be in YYYY-MM-DD format")},
 		{"Czech. Republic", "", "", fmt.Errorf("transaction date must be in YYYY-MM-DD format")},
 	}
 
 	for _, tt := range getRequestFilterTests {
-		gotFilter, gotErr := getRequestFilter(tt.country, &model.Transaction{TransactionDate: tt.transactionDate})
+		gotFilter, gotErr := getRequestQuery(tt.country, &model.Transaction{TransactionDate: tt.transactionDate})
 		if tt.expectedError == nil {
 			assert.NoError(t, gotErr)
 			assert.Equal(t, tt.expectedFilter, gotFilter)

--- a/service/treasury_test.go
+++ b/service/treasury_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/mvfavila/transactions/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRoundTripper struct {
+	mockResponse *http.Response
+	mockError    error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.mockError != nil {
+		return nil, m.mockError
+	}
+	return m.mockResponse, nil
+}
+
+func TestFetchExchangeRates(t *testing.T) {
+	// Mock response body
+	mockResponseBody := `{
+		"data": [
+			{"currency_code": "USD", "currency_name": "US Dollar", "exchange_rate": "1.0", "rate_date": "2025-01-13", "source_updated": "2025-01-13T12:00:00Z"}
+		],
+		"meta": {},
+		"links": {}
+	}`
+
+	// Create a mock HTTP client
+	mockClient := &http.Client{
+		Transport: &mockRoundTripper{
+			mockResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(mockResponseBody)),
+			},
+		},
+	}
+
+	// Call the function
+	rates, err := FetchExchangeRates(mockClient, "Brazil", &model.Transaction{TransactionDate: "2025-01-13"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Assert the results
+	if len(rates) != 1 {
+		t.Fatalf("expected 1 rate, got %d", len(rates))
+	}
+
+	expectedRate := "US Dollar"
+	if rates[0].CurrencyName != expectedRate {
+		t.Errorf("expected currency name %s, got %s", expectedRate, rates[0].CurrencyName)
+	}
+}
+
+func TestFetchExchangeRates_Error(t *testing.T) {
+	// Create a mock HTTP client with an error response
+	mockClient := &http.Client{
+		Transport: &mockRoundTripper{
+			mockError: errors.New("mock error"),
+		},
+	}
+
+	// Call the function
+	_, err := FetchExchangeRates(mockClient, "Brazil", &model.Transaction{TransactionDate: "2025-01-13"})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to make request to Treasury API")
+	assert.Contains(t, err.Error(), "mock error")
+}
+
+func TestGetDateMinusSixMonths(t *testing.T) {
+	tests := []struct {
+		inputDate       string
+		expectedOutput  string
+		expectedSuccess bool
+	}{
+		{
+			inputDate:       "2020-01-01",
+			expectedOutput:  "2019-07-01",
+			expectedSuccess: true,
+		},
+		{
+			inputDate:       "2020-02-29",
+			expectedOutput:  "2019-08-29",
+			expectedSuccess: true,
+		},
+		{
+			inputDate:       "abc",
+			expectedOutput:  "",
+			expectedSuccess: false,
+		},
+		{
+			inputDate:       "",
+			expectedOutput:  "",
+			expectedSuccess: false,
+		},
+	}
+
+	for _, test := range tests {
+		got, err := getDateMinusSixMonths(test.inputDate)
+		if test.expectedSuccess {
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedOutput, got)
+		} else {
+			assert.Error(t, err)
+			assert.Equal(t, "", got)
+		}
+	}
+}
+
+func TestGetRequestFilter(t *testing.T) {
+	var getRequestFilterTests = []struct {
+		country         string
+		transactionDate string
+		expectedFilter  string
+		expectedError   error
+	}{
+		{"Autralia", "2020-01-01", "country:eq:Autralia,effective_date:gte:2019-07-01,effective_date:lte:2020-01-01", nil},
+		{"Austria", "2020-02-29", "country:eq:Austria,effective_date:gte:2019-08-29,effective_date:lte:2020-02-29", nil},
+		{"Brazil", "abc", "", fmt.Errorf("transaction date must be in YYYY-MM-DD format")},
+		{"Czech. Republic", "", "", fmt.Errorf("transaction date must be in YYYY-MM-DD format")},
+	}
+
+	for _, tt := range getRequestFilterTests {
+		gotFilter, gotErr := getRequestFilter(tt.country, &model.Transaction{TransactionDate: tt.transactionDate})
+		if tt.expectedError == nil {
+			assert.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedFilter, gotFilter)
+		} else {
+			assert.EqualError(t, gotErr, tt.expectedError.Error())
+			assert.Equal(t, "", gotFilter)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #11 

# Changes

- Add treasury integration
- Expect country and transaction date as input to integration
- Filter response by `country` and the `effective_date` up to 6 months prior to given date 
- Add sorting to Treasury API request (to have the latest exchange at the top of the response)